### PR TITLE
Update PaginationWrapper.ts

### DIFF
--- a/packages/DJS-Button-Pages/src/Structures/PaginationWrapper.ts
+++ b/packages/DJS-Button-Pages/src/Structures/PaginationWrapper.ts
@@ -333,10 +333,13 @@ export default class PaginationWrapper implements PaginationData
      */
     public async interactionReply(interaction:RepliableInteraction, options:InteractionReplyOptions = {}, page = 0): Promise<PaginationSent>
     {
-        if (!interaction.deferred)  
-            await interaction.deferReply({ephemeral: options.ephemeral
-                ? true
-                : false});
+        if (!interaction.deferred) {
+            if (options.ephemeral) {
+                await interaction.deferReply({ flags: [ "Ephemeral" ] });
+            } else {
+                await interaction.deferReply();
+            }
+        }
 
         if (page < 0 || !Number.isInteger(page))
             throw new RangeError("[DJS-Button-Pages]: Page number should be integer!");


### PR DESCRIPTION
Fix "ephemeral" option deprecation & replace with flags option

Discord.js 14 does not support passing an "ephemeral" option anymore, and has deprecated it. I noticed this while using this package, so I fixed it in the code by passing the new "flags" option in the event that a user does want their pages to be ephemeral. This does not include any breaking changes, I just fixed a deprecated option.
